### PR TITLE
Add AMD support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -15,6 +15,48 @@ function __extends(child: any, parent: any): void {
     }
 }
 
+function define(id: string, deps: string[], factory: Function): void {
+    if (define.modules[id] !== undefined) {
+        throw new Error(`${id} is defined`);
+    }
+    define.modules[id] = {
+        deps: deps,
+        exports: undefined,
+        factory: factory
+    };
+}
+
+namespace define {
+    export var amd: {} = {};
+    export var modules: {
+        [key: string]: {
+            deps: string[];
+            exports: any;
+            factory: Function;
+        };
+    } = {};
+}
+
+function requirejs(id: string): any {
+    var _module = define.modules[id];
+    if (_module === undefined) {
+        throw new Error(`${id} is undefined`);
+    }
+    _module.factory.apply(null, _module.deps.map((name) => {
+        if (name === "require") {
+            return requirejs;
+        }
+        if (name === "exports") {
+            _module.exports = {};
+            return _module.exports;
+        }
+        return requirejs(name);
+    }));
+    return _module.exports;
+}
+
 if (global) {
     global.__extends = __extends;
+    global.define = define;
+    global.requirejs = requirejs;
 }

--- a/spec.ts
+++ b/spec.ts
@@ -1,6 +1,10 @@
 declare var global: any;
 
 describe("tsenv", () => {
+    beforeEach(() => {
+        global.define.modules = {};
+    });
+
     describe("__extends", () => {
         it("should handle null", () => {
             var Foo: any = (function(__super: any) {
@@ -51,6 +55,64 @@ describe("tsenv", () => {
             var foo = new Foo();
             expect(foo.bar()).toBe("bar");
             expect(foo.foo()).toBe("foo");
+        });
+    });
+
+    describe("define", () => {
+        it("should be a valid AMD provider", () => {
+            expect(global.define.amd).toBeDefined();
+        });
+
+        it("should define a module", () => {
+            var id = "foo";
+            var deps = [];
+            var factory = () => { };
+            global.define(id, deps, factory);
+            var _module = global.define.modules[id];
+            expect(_module).toBeDefined();
+            expect(_module.deps).toBe(deps);
+            expect(_module.exports).not.toBeDefined();
+            expect(_module.factory).toBe(factory);
+        });
+
+        it("should throw an error if defined twice", () => {
+            global.define("foo", [], () => { });
+            expect(() => {
+                global.define("foo", [], () => { });
+            }).toThrow();
+        });
+    });
+
+    describe("requirejs", () => {
+        it("should handle exports", () => {
+            var id = "foo";
+            var deps = ["exports"];
+            var foo = {};
+            var factory = (exports: any) => {
+                exports.foo = foo;
+            };
+            global.define(id, deps, factory);
+            expect(global.requirejs(id).foo).toBe(foo);
+        });
+
+        it("should handle require", () => {
+            var id = "foo";
+            var deps = ["exports"];
+            var foo = {};
+            var factory = (exports: any) => {
+                exports.foo = foo;
+            };
+            global.define(id, deps, factory);
+            global.define("bar", ["require", "exports"], (require: any, exports: any) => {
+                exports.foo = require("foo").foo;
+            });
+            expect(global.requirejs("bar").foo).toBe(foo);
+        });
+
+        it("should throw an error if not defined", () => {
+            expect(() => {
+                global.requirejs("foo");
+            }).toThrow();
         });
     });
 });


### PR DESCRIPTION
This provides the most minimal support for AMD on the client possible.
The code assumes that TypeScript will not allow cycles within the
modules.
